### PR TITLE
Skasowanie mapowania Poniatowskiego

### DIFF
--- a/mapping.py
+++ b/mapping.py
@@ -290,7 +290,6 @@ addr_map = {
  'Pobożnego H.': 'Henryka Pobożnego',
  'Polipol Aleja': 'aleja Polipol',
  'Poniatowskiego J.': 'Józefa Poniatowskiego',
- 'Poniatowskiego': 'Stanisława Augusta Poniatowskiego',
  'Popiełuszki Jerzego': 'Jerzego Popiełuszki',
  'Powstańców Wlkp.': 'Powstańców Wielkopolskich',
  'Poświatowskiej H.': 'Haliny Poświatowskiej',


### PR DESCRIPTION
Poniatowskiego nie powinno być mapowane na Stanisława Augusta Poniatowskiego, ponieważ jest to niejednoznaczne. 
addr:street:sym_ul = 17100 wskazuje na ul. Poniatowskiego, więc może chodzić zarówno o S.A. Poniatowskiego jak i Józefa Poniatowskiego.